### PR TITLE
Make creation of button images much faster

### DIFF
--- a/Pod/Classes/MRGRoundButton.h
+++ b/Pod/Classes/MRGRoundButton.h
@@ -59,4 +59,7 @@ typedef NS_ENUM(NSInteger, MRGRoundButtonTitlePosition) {
 - (void)setNeedsUpdate;
 - (void)updateIfNeeded;
 - (void)update;
+
+- (void)setImage:(UIImage *)image forState:(UIControlState)state NS_UNAVAILABLE;
+- (void)setBackgroundImage:(UIImage *)image forState:(UIControlState)state NS_UNAVAILABLE;
 @end

--- a/Pod/Classes/MRGRoundButton.m
+++ b/Pod/Classes/MRGRoundButton.m
@@ -201,6 +201,11 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
     }
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self setNeedsUpdate];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
     if (context == MRGRoundButton_setNeedsUpdate) {
         [self setNeedsUpdate];

--- a/Pod/Classes/MRGRoundButton.m
+++ b/Pod/Classes/MRGRoundButton.m
@@ -351,7 +351,6 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
-    
     [self updateIfNeeded];
     
     if ([[self titleForState:UIControlStateNormal] length] == 0) {
@@ -359,6 +358,18 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
     }
     
     size = [super sizeThatFits:size];
+    size.height = CGRectGetMaxY([self titleRectForContentRect:[self contentRectForBounds:CGRectMake(0, 0, size.width, size.height)]]);
+    return size;
+}
+
+- (CGSize)intrinsicContentSize {
+    [self updateIfNeeded];
+    
+    if ([[self titleForState:UIControlStateNormal] length] == 0) {
+        return [super intrinsicContentSize];
+    }
+    
+    CGSize size = [super intrinsicContentSize];
     size.height = CGRectGetMaxY([self titleRectForContentRect:[self contentRectForBounds:CGRectMake(0, 0, size.width, size.height)]]);
     return size;
 }


### PR DESCRIPTION
Do not use `[UIImage imageNamedRetina:tintColor:]` to tint images anymore. It required to create an image for each available trait collection and highlighted / selected combinations and to redraw the ellipse for each icons instead of once for each size/properties.

Instead, add a new `iconImageView` layer and use `tintColor` along with template rendering mode to tint the icon.