### PR TITLE
Fix default rendering icon

### DIFF
--- a/Pod/Classes/MRGRoundButton.m
+++ b/Pod/Classes/MRGRoundButton.m
@@ -272,25 +272,26 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
 - (UIImage *)iconForState {
     UIImage *iconForState = nil;
     
-    NSString *key = nil;
+    id key = nil;
     NSCache *imageCache = self.class.imageCache;
+    
+    BOOL isTinted = (!self.isHighlighted ? self.iconTintColor : (self.iconTintColorHighlighted ?: self.iconTintColor)) != nil;
     
     if (!self.isSelected) {
         if (self.iconName.length > 0) {
-            iconForState = [imageCache objectForKey:(key = self.iconName)] ?: [UIImage imageNamed:key];
+            iconForState = [imageCache objectForKey:(key = @[self.iconName, @(isTinted)])] ?: [UIImage imageNamed:self.iconName];
         } else if (self.iconFilePath.length > 0) {
-            iconForState = [imageCache objectForKey:(key = self.iconFilePath)] ?: [UIImage imageNamed:key];
+            iconForState = [imageCache objectForKey:(key = @[self.iconFilePath, @(isTinted)])] ?: [UIImage imageNamed:self.iconFilePath];
         }
     } else {
         if (self.selectedIconName.length > 0) {
-            iconForState = [imageCache objectForKey:(key = self.selectedIconName)] ?: [UIImage imageNamed:key];
+            iconForState = [imageCache objectForKey:(key = @[self.selectedIconName, @(isTinted)])] ?: [UIImage imageNamed:self.selectedIconName];
         } else if (self.selectedIconFilePath.length > 0) {
-            iconForState = [imageCache objectForKey:(key = self.selectedIconFilePath)] ?: [UIImage imageNamed:key];
+            iconForState = [imageCache objectForKey:(key = @[self.selectedIconFilePath, @(isTinted)])] ?: [UIImage imageNamed:self.selectedIconFilePath];
         }
     }
     
     if (iconForState != nil) {
-        BOOL isTinted = (!self.isHighlighted ? self.iconTintColor : (self.iconTintColorHighlighted ?: self.iconTintColor)) != nil;
         if (isTinted) {
             if (iconForState.renderingMode != UIImageRenderingModeAlwaysTemplate) {
                 iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/Pod/Classes/MRGRoundButton.m
+++ b/Pod/Classes/MRGRoundButton.m
@@ -291,14 +291,8 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
         }
     }
     
-    if (iconForState != nil) {
-        if (isTinted) {
-            if (iconForState.renderingMode != UIImageRenderingModeAlwaysTemplate) {
-                iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-            }
-        } else {
-            iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-        }
+    if (isTinted && iconForState != nil && iconForState.renderingMode != UIImageRenderingModeAlwaysTemplate) {
+        iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
     
     if ((iconForState != nil) && key != nil) {

--- a/Pod/Classes/MRGRoundButton.m
+++ b/Pod/Classes/MRGRoundButton.m
@@ -289,8 +289,15 @@ static void *MRGRoundButton_setNeedsUpdate = &MRGRoundButton_setNeedsUpdate;
         }
     }
     
-    if (iconForState != nil && iconForState.renderingMode != UIImageRenderingModeAlwaysTemplate) {
-        iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    if (iconForState != nil) {
+        BOOL isTinted = (!self.isHighlighted ? self.iconTintColor : (self.iconTintColorHighlighted ?: self.iconTintColor)) != nil;
+        if (isTinted) {
+            if (iconForState.renderingMode != UIImageRenderingModeAlwaysTemplate) {
+                iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+            }
+        } else {
+            iconForState = [iconForState imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        }
     }
     
     if ((iconForState != nil) && key != nil) {


### PR DESCRIPTION
Do not force `imageWithRenderingMode` to `UIImageRenderingModeAlwaysTemplate` when there is no `tintColor` because it makes the image to lose original colors.